### PR TITLE
Update base class; add comparison operators

### DIFF
--- a/boomdiff/autodiff.py
+++ b/boomdiff/autodiff.py
@@ -754,6 +754,41 @@ class AD():
         7.3890560989306495
         """
         return np.e**x
+    
+    
+    
+    @staticmethod
+    def logistic(x, x_0=0, k=1, L=1):
+        """A static method to calculate the logistic function of an AD instance or
+        float. Logistic function L/(1+e^(-k(x-x_0))). More commonly used as 1/(1+e^(-x))
+        Parameters
+        ----------
+        x: AD class instance of float
+            Elements to be used as base of logistic function. Can be an AD class instance,
+            which will update both the function value and partial derivative dictionary; or
+            a constant, which will return a constant output
+        x_0: int or float 
+            This represents the center of logistic function; default set to zero, i.e.
+            logistic function centered at zero 0.
+        k: int or float
+            Logistic growth rate of function; default set to 1. Larger values of k imply
+            steeper logistic growth rate
+        L: int or float
+            Maximum value of logistic function; default set to 1.
+        Returns
+        -------
+        A new AD class with updated information; otherwise a float value.
+        
+        Examples
+        --------
+        >>> x = AD(1.5)
+        >>> print(AD.logistic(x))
+        0.8175744761936437 ({'x1': 0.14914645207033284})
+        >>> f = x + AD(-0.5, {'x2': 1})
+        >>> print(AD.logistic(f))
+        0.7310585786300049 ({'x1': 0.19661193324148188, 'x2': 0.19661193324148188})
+        """
+        return L/(1 + AD.exp(-k * (x - x_0)))
 
 if __name__ == '__main__':
     import doctest

--- a/boomdiff/autodiff.py
+++ b/boomdiff/autodiff.py
@@ -3,20 +3,23 @@ import itertools
 
 class AD():
 
-    def __init__(self, eval_pt, der_dict={'x1':1}):
+    def __init__(self, eval_pt, name=None, der_dict=None):
         """Initializes class structure
         Parameters
         ----------
         eval_pt : float
             Value of the current function/variable
+        name: str
+            Name of variable to be included; will automatically
+            set this to a seed value of 1.
         der_dict : dict
-            derivative value dictionary of all variables
+            derivative value dictionary of all variables; default value set to None
         Returns
         -------
         None.
         Examples
         --------
-        >>> x1 = AD(3.6, {'x1':1})
+        >>> x1 = AD(3.6, der_dict = {'x1':1})
         >>> x1.func_val
         3.6
         >>> x1.partial_dict
@@ -27,17 +30,38 @@ class AD():
             self.func_val = eval_pt
         else:
             raise ValueError('All valuess should be real float or integer numbers!')
-
-        # Set partial derivative dictionary
-        # Will assume form of x_1, ..., x_n
-        if not isinstance(der_dict, dict):
-            raise ValueError('der_dict must be type dict!')
+            
+        # Set up base functionality - convert all string names to be lowercase
+        # If name and der_dict both not none, ensure that names match
+        if name is not None and der_dict is not None:
+            if [name] != list(der_dict.keys()):
+                raise Exception('name entered must match name of der_dict')            
+        
         try:
-            for key, val in der_dict.items():
-                assert isinstance(der_dict[key], (int, float))
-            self.partial_dict = der_dict
-        except:
-            raise ValueError('All derivatives must be type int or float, to make the expression real and valid!')
+            name_l = name.lower()
+            self.partial_dict = {}
+            self.partial_dict[name_l] = 1
+            
+        except(AttributeError):
+            if name is None and der_dict is None:
+                self.partial_dict = {'x1': 1}
+            
+            elif name is not None and der_dict is None:
+                if not isinstance(name, str):
+                    raise AttributeError('name must be str')
+ 
+            elif name is None and der_dict is not None:
+                # If Set partial derivative dictionary
+                # Will assume form of x_1, ..., x_n
+                if not isinstance(der_dict, dict):
+                    raise ValueError('der_dict must be type dict!')
+                try:
+                    for key, val in der_dict.items():
+                        assert isinstance(der_dict[key], (int, float))
+                    self.partial_dict = der_dict
+                except:
+                    raise ValueError('All derivatives must be type int or float, to make the expression real and valid!')
+
 
     def set_params(self, att, val):
         """Set parameters for class; to be used in selective cases only
@@ -79,6 +103,26 @@ class AD():
 
     def __repr__(self):
         return f'{self.func_val} ({self.partial_dict})'
+    
+    # Define equality and inequality messages
+    def __eq__(self, other):
+        """AD objects must have same function value and partial derivative
+        dictionary to be considered equal
+        """
+        if isinstance(other, AD):
+            return (self.func_val == other.func_val) and (self.partial_dict == other.partial_dict)
+        else:   
+            return False
+    
+    def __ne__(self, other):
+        """AD objects are never equal to non-AD objects; if other AD object, 
+        will not be equal if either function value or partial derivatives are not equal
+        """
+        if isinstance(other, AD):
+            return (self.func_val != other.func_val) or (self.partial_dict != other.partial_dict)
+        else:
+            return True
+    
 
     def __add__(self, other):
         """Overload addition operation '+'
@@ -93,8 +137,8 @@ class AD():
         A new AD class instance with updated information
         Examples
         --------
-        >>> x1 = AD(3.6, {'x1': 1})
-        >>> x2 = AD(5.2, {'x2': 1.5})
+        >>> x1 = AD(3.6, der_dict={'x1': 1})
+        >>> x2 = AD(5.2, der_dict={'x2': 1.5})
         >>> f1 = x1 + x2
         >>> print(f1.func_val, f1.partial_dict)
         8.8 {'x1': 1, 'x2': 1.5}
@@ -108,10 +152,10 @@ class AD():
             new_der_dict = {}
             for k in itertools.chain(self.partial_dict.keys(), other.partial_dict.keys()):
                 new_der_dict[k] = self.partial_dict.get(k,0) + other.partial_dict.get(k,0)
-            return AD(self.func_val+other.func_val, new_der_dict)
+            return AD(self.func_val+other.func_val, der_dict=new_der_dict)
         except AttributeError:
             # If other is not an AD class instance, treat as a constant
-            return AD(self.func_val+other, self.partial_dict)
+            return AD(self.func_val+other, der_dict=self.partial_dict)
 
     def __radd__(self, other):
         """Overload to make sure commutativity of addition '+'
@@ -126,11 +170,11 @@ class AD():
         A new AD class instance with updated information
         Examples
         --------
-        >>> x1 = AD(3.6, {'x1': 1})
+        >>> x1 = AD(3.6, der_dict={'x1': 1})
         >>> f1 = 10 + x1
         >>> print(f1.func_val, f1.partial_dict)
         13.6 {'x1': 1}
-        >>> f0 = AD(3.6, {'x1': 1, 'x2': 4})
+        >>> f0 = AD(3.6, der_dict={'x1': 1, 'x2': 4})
         >>> f1 = 10 + f0
         >>> print(f1.func_val, f1.partial_dict)
         13.6 {'x1': 1, 'x2': 4}
@@ -139,7 +183,7 @@ class AD():
         # treat as a constant
         # just return the partial dictionary of the self instance 
         new_der_dict = dict(self.partial_dict)
-        return AD(other+self.func_val, new_der_dict)
+        return AD(other+self.func_val, der_dict=new_der_dict)
 
     def __sub__(self, other):
         """Overload subtraction operation '-'
@@ -154,11 +198,11 @@ class AD():
         A new AD class instance with updated information
         Examples
         --------
-        >>> x1 = AD(3.6, {'x1': 1})
+        >>> x1 = AD(3.6, der_dict={'x1': 1})
         >>> f1 = x1 - 10
         >>> print(f1.func_val, f1.partial_dict)
         -6.4 {'x1': 1}
-        >>> x2 = AD(2.0, {'x2': 3.4})
+        >>> x2 = AD(2.0, der_dict={'x2': 3.4})
         >>> f2 = x1 - x2
         >>> print(f2.func_val, f2.partial_dict)
         1.6 {'x1': 1, 'x2': -3.4}
@@ -169,10 +213,10 @@ class AD():
             new_der_dict = {}
             for k in itertools.chain(self.partial_dict.keys(), other.partial_dict.keys()):
                 new_der_dict[k] = self.partial_dict.get(k,0) - other.partial_dict.get(k,0)
-            return AD(self.func_val-other.func_val, new_der_dict)
+            return AD(self.func_val-other.func_val, der_dict=new_der_dict)
         except AttributeError:
             # If other is not an AD class instance, treat as a constant
-            return AD(self.func_val-other, self.partial_dict)
+            return AD(self.func_val-other, der_dict=self.partial_dict)
 
     def __rsub__(self, other):
         """Overload to make sure commutativity of subtraction '-'
@@ -187,11 +231,11 @@ class AD():
         A new AD class instance with updated information
         Examples
         --------
-        >>> x1 = AD(3.6, {'x1': 1})
+        >>> x1 = AD(3.6, der_dict={'x1': 1})
         >>> f1 = 10 - x1
         >>> print(f1.func_val, f1.partial_dict) 
         6.4 {'x1': -1}
-        >>> f0 = AD(3.6, {'x1': 1, 'x2': 3})
+        >>> f0 = AD(3.6, der_dict={'x1': 1, 'x2': 3})
         >>> f1 = 10 - f0
         >>> print(f1.func_val, f1.partial_dict)
         6.4 {'x1': -1, 'x2': -3}
@@ -201,7 +245,7 @@ class AD():
         new_der_dict = {}
         for key, value in self.partial_dict.items():
             new_der_dict[key] = -value
-        return AD(other-self.func_val, new_der_dict)
+        return AD(other-self.func_val, der_dict=new_der_dict)
 
     def __mul__(self, other):
         """Overload multiplication operation '*'
@@ -216,7 +260,7 @@ class AD():
         A new AD class instance with updated information
         Examples
         --------
-        >>> x1 = AD(1, {'x1': 1})
+        >>> x1 = AD(1, der_dict={'x1': 1})
         >>> f1 = x1*10.0
         >>> print(f1.func_val, f1.partial_dict)
         10.0 {'x1': 10.0}
@@ -226,8 +270,8 @@ class AD():
         >>> f2 = f1 * x2
         >>> print(f2.func_val, f2.partial_dict)
         20.0 {'x1': 54.0}
-        >>> a = AD(2, {'a': 1})
-        >>> b = AD(4, {'b': 1})
+        >>> a = AD(2, der_dict={'a': 1})
+        >>> b = AD(4, der_dict={'b': 1})
         >>> f3 = a*b
         >>> print(f3.func_val, f3.partial_dict)
         8 {'a': 4, 'b': 2}
@@ -242,13 +286,13 @@ class AD():
                 new_der_dict[k] = self.partial_dict.get(k,0)*other.func_val + other.partial_dict.get(k,0)*self.func_val
             #print(new_der_dict)
             #print(self.partial_dict)
-            return AD(self.func_val*other.func_val, new_der_dict)
+            return AD(self.func_val*other.func_val, der_dict=new_der_dict)
         except AttributeError:
             # If other is not an AD class instance, treat as a constant
             new_der_dict = {}
             for key, value in self.partial_dict.items():
                 new_der_dict[key] = value*other
-            return AD(self.func_val*other, new_der_dict)
+            return AD(self.func_val*other, der_dict=new_der_dict)
 
     def __rmul__(self, other):
         """Overload to make sure commutativity of operation '*'
@@ -263,7 +307,7 @@ class AD():
         A new AD class instance with updated information
         Examples
         --------
-        >>> x1 = AD(1, {'x1': 1})
+        >>> x1 = AD(1, der_dict={'x1': 1})
         >>> f1 = 10.0*x1
         >>> print(f1.func_val, f1.partial_dict)
         10.0 {'x1': 10.0}
@@ -273,8 +317,8 @@ class AD():
         >>> f2 = f1 * x2
         >>> print(f2.func_val, f2.partial_dict)
         20.0 {'x1': 54.0}
-        >>> a = AD(2, {'a': 1})
-        >>> b = AD(4, {'b': 1})
+        >>> a = AD(2, der_dict={'a': 1})
+        >>> b = AD(4, der_dict={'b': 1})
         >>> f3 = (4*a + 6*b)*a
         >>> print(f3.func_val, f3.partial_dict)
         64 {'a': 40, 'b': 12}
@@ -284,7 +328,7 @@ class AD():
         new_der_dict = {}
         for key, value in self.partial_dict.items():
             new_der_dict[key] = value*other
-        return AD(other*self.func_val, new_der_dict)
+        return AD(other*self.func_val, der_dict=new_der_dict)
 
     def __truediv__(self, other):
         """Overload division operation '/'
@@ -299,7 +343,7 @@ class AD():
         A new AD class instance with updated information
         Examples
         --------
-        >>> x1 = AD(1., {'x1':1})
+        >>> x1 = AD(1., der_dict={'x1':1})
         >>> f1 = x1/10.
         >>> print(f1.func_val, f1.partial_dict)
         0.1 {'x1': 0.1}
@@ -307,8 +351,8 @@ class AD():
         >>> f2 = x2/x1
         >>> print(f2.func_val, f2.partial_dict)
         3.4 {'x1': 0.0}
-        >>> a = AD(2, {'a': 1})
-        >>> b = AD(4, {'b': 1})
+        >>> a = AD(2, der_dict={'a': 1})
+        >>> b = AD(4, der_dict={'b': 1})
         >>> f3 = a/b
         >>> print(f3.func_val, f3.partial_dict)
         0.5 {'a': 0.25, 'b': -0.125}
@@ -318,13 +362,13 @@ class AD():
             new_der_dict = {}
             for k in itertools.chain(self.partial_dict.keys(), other.partial_dict.keys()):
                 new_der_dict[k] = (self.partial_dict.get(k,0)*other.func_val - other.partial_dict.get(k,0)*self.func_val)/(other.func_val**2)
-            return AD(self.func_val/other.func_val, new_der_dict)
+            return AD(self.func_val/other.func_val, der_dict=new_der_dict)
         except AttributeError:
             # If other is not an AD class instance, treat as a constant
             new_der_dict = {}
             for key, value in self.partial_dict.items():
                 new_der_dict[key] = value/other
-            return AD(self.func_val/other, new_der_dict)
+            return AD(self.func_val/other, der_dict=new_der_dict)
 
     def __rtruediv__(self, other):
         """Overload to make right version of operation '/' works
@@ -339,7 +383,7 @@ class AD():
         A new AD class instance with updated information
         Examples
         --------
-        >>> x1 = AD(1., {'x1':1})
+        >>> x1 = AD(1., der_dict={'x1':1})
         >>> f1 = 10.0/x1
         >>> print(f1.func_val, f1.partial_dict)
         10.0 {'x1': -10.0}
@@ -347,8 +391,8 @@ class AD():
         >>> f2 = x2/x1
         >>> print(f2.func_val, f2.partial_dict)
         2.0 {'x1': 1.4}
-        >>> a = AD(2, {'a': 1})
-        >>> b = AD(4, {'b': 1})
+        >>> a = AD(2, der_dict={'a': 1})
+        >>> b = AD(4, der_dict={'b': 1})
         >>> f3 = 16./(a*b)
         >>> print(f3.func_val, f3.partial_dict)
         2.0 {'a': -1.0, 'b': -0.5}
@@ -358,7 +402,7 @@ class AD():
         new_der_dict = {}
         for key, value in self.partial_dict.items():
             new_der_dict[key] = -other*value/(self.func_val**2)
-        return AD(other/self.func_val, new_der_dict)
+        return AD(other/self.func_val, der_dict=new_der_dict)
 
     def __pow__(self, other):
         """Overload power operation '**'
@@ -373,19 +417,19 @@ class AD():
         A new AD class instance with updated information
         Examples
         --------
-        >>> x = AD(2, {'x1': 1})
+        >>> x = AD(2, der_dict={'x1': 1})
         >>> print(x**3)
         8 ({'x1': 12})
-        >>> x = AD(2, {'x1': 1.})
+        >>> x = AD(2, der_dict={'x1': 1.})
         >>> f1 = AD.sin(x**3)
         >>> print(f1**3)
         0.9684132754691923 ({'x1': -5.127111370310495})
-        >>> x = AD(2, {'x': 1})
+        >>> x = AD(2, der_dict={'x': 1})
         >>> f2 = x**x
         >>> print(f2.func_val, f2.partial_dict)
         4 {'x': 6.772588722239782}
-        >>> a = AD(2, {'a': 1})
-        >>> b = AD(4, {'b': 1})
+        >>> a = AD(2, der_dict={'a': 1})
+        >>> b = AD(4, der_dict={'b': 1})
         >>> f3 = a**b
         >>> print(f3.func_val, f3.partial_dict)
         16 {'a': 32.0, 'b': 11.090354888959125}
@@ -397,13 +441,13 @@ class AD():
                 new_der_dict[k] = self.func_val**other.func_val *\
                                     (self.partial_dict.get(k,0)*other.func_val/self.func_val +\
                                      other.partial_dict.get(k,0)*np.log(self.func_val))
-            return AD(self.func_val**other.func_val, new_der_dict)
+            return AD(self.func_val**other.func_val, der_dict=new_der_dict)
         except AttributeError:
             # If other is not an AD class instance, treat as a constant
             new_der_dict = {}
             for key, value in self.partial_dict.items():
                 new_der_dict[key] = other * self.func_val**(other-1) * value
-            return AD(self.func_val**other, new_der_dict)
+            return AD(self.func_val**other, der_dict=new_der_dict)
         
         
     def __rpow__(self, other):
@@ -419,15 +463,15 @@ class AD():
         A new AD class instance with updated information
         Examples
         --------
-        >>> x = AD(2, {'x1': 1})
+        >>> x = AD(2, der_dict={'x1': 1})
         >>> print(3**x)
         9 ({'x1': 9.887510598012987})
-        >>> x = AD(2, {'x1': 1.})
+        >>> x = AD(2, der_dict={'x1': 1.})
         >>> f1 = AD.sin(3**x)
         >>> print(f1**3)
         0.06999488183019169 ({'x1': -4.5902134148312985})
-        >>> a = AD(2, {'a': 1})
-        >>> b = AD(3, {'b': 1})
+        >>> a = AD(2, der_dict={'a': 1})
+        >>> b = AD(3, der_dict={'b': 1})
         >>> f2 = 2**(a+b)
         >>> print(f2.func_val, f2.partial_dict)
         32 {'a': 22.18070977791825, 'b': 22.18070977791825}
@@ -437,7 +481,7 @@ class AD():
         new_der_dict = {}
         for key, value in self.partial_dict.items():
             new_der_dict[key] = other**self.func_val * np.log(other) * value
-        return AD(other**self.func_val, new_der_dict)
+        return AD(other**self.func_val, der_dict=new_der_dict)
 
     def __neg__(self):
         """Overload '-' to return the negative of an object
@@ -452,7 +496,7 @@ class AD():
         
         Examples
         --------
-        >>> x1 = AD(1., {'x1':1})
+        >>> x1 = AD(1., der_dict={'x1':1})
         >>> f_x1 = -x1
         >>> print(f_x1.func_val, f_x1.partial_dict)
         -1.0 {'x1': -1}
@@ -460,7 +504,7 @@ class AD():
         >>> f_x2_x1 = -x2 + x1
         >>> print(f_x2_x1.func_val, f_x2_x1.partial_dict)
         -2.0 {'x1': -2}
-        >>> f2 = AD(2, {'a': 1}) + AD(4, {'b': 1})
+        >>> f2 = AD(2, 'a') + AD(4, 'b')
         >>> print(-f2)
         -6 ({'a': -1, 'b': -1})
         """
@@ -482,7 +526,7 @@ class AD():
         A new AD class with updated information
         Examples
         --------
-        >>> x1 = AD(np.pi/2, {'x1': 1.})
+        >>> x1 = AD(np.pi/2, 'x1')
         >>> f1 = AD.sin(x1)
         >>> print(f1.func_val, f1.partial_dict)
         1.0 {'x1': 6.123233995736766e-17}
@@ -495,7 +539,7 @@ class AD():
             new_der_dict = x.partial_dict.copy()
             for var in new_der_dict.keys():
                 new_der_dict[var] = np.cos(x.func_val)*new_der_dict[var]
-            return AD(np.sin(x.func_val), new_der_dict)
+            return AD(np.sin(x.func_val), der_dict=new_der_dict)
         except AttributeError:
             # if x is not an AD class instance, treat as a constant
             return np.sin(x)
@@ -515,7 +559,7 @@ class AD():
         A new AD class with updated information
         Examples
         --------
-        >>> x1 = AD(np.pi/2, {'x1': 1.})
+        >>> x1 = AD(np.pi/2, 'x1')
         >>> f1 = AD.cos(x1)
         >>> print(f1.func_val.round(1), f1.partial_dict)
         0.0 {'x1': -1.0}
@@ -528,7 +572,7 @@ class AD():
             new_der_dict = x.partial_dict.copy()
             for var in new_der_dict.keys():
                 new_der_dict[var] = -np.sin(x.func_val)*new_der_dict[var]
-            return AD(np.cos(x.func_val), new_der_dict)
+            return AD(np.cos(x.func_val), der_dict=new_der_dict)
         except AttributeError:
             # if x is not an AD class instance, treat as a constant
             return np.cos(x)
@@ -547,7 +591,7 @@ class AD():
         A new AD class with updated information
         Examples
         --------
-        >>> x1 = AD(np.pi, {'x1': 1.})
+        >>> x1 = AD(np.pi,'x1')
         >>> f1 = AD.tan(x1)
         >>> print(f1.func_val.round(1), f1.partial_dict)
         -0.0 {'x1': 1.0}
@@ -560,7 +604,7 @@ class AD():
             new_der_dict = x.partial_dict.copy()
             for var in new_der_dict.keys():
                 new_der_dict[var] = new_der_dict[var]/(np.cos(x.func_val)**2)
-            return AD(np.tan(x.func_val), new_der_dict)
+            return AD(np.tan(x.func_val), der_dict=new_der_dict)
         except AttributeError:
             # if x is not an AD class instance, treat as a constant
             return np.tan(x)
@@ -580,14 +624,14 @@ class AD():
         
         Examples
         --------
-        >>> x1 = AD(1.0, {'x1': 1.0})
+        >>> x1 = AD(1.0, 'x1')
         >>> f1 = AD.sqrt(x1)
         >>> print(f1.func_val, f1.partial_dict)
         1.0 {'x1': 0.5}
         >>> f2 = AD.sqrt(1.0)
         >>> print(f2)
         1.0
-        >>> x2 = AD(0, {'x2': 1})
+        >>> x2 = AD(0, 'x2')
         >>> f3 = AD.sqrt(AD.cos(x2))
         >>> print(f3.func_val, f3.partial_dict)
         1.0 {'x2': -0.0}
@@ -597,7 +641,7 @@ class AD():
             new_der_dict = x.partial_dict.copy()
             for var in new_der_dict.keys():
                 new_der_dict[var] = new_der_dict[var]/(2 * (x.func_val**(1/2)))
-            return AD(np.sqrt(x.func_val), new_der_dict)
+            return AD(np.sqrt(x.func_val), der_dict=new_der_dict)
         except AttributeError:
             # if x is not an AD class instance, treat as a constant
             return np.sqrt(x)
@@ -620,7 +664,7 @@ class AD():
         A new AD class with updated information
         Examples
         --------
-        >>> x1 = AD(np.e**2, {'x1': 1.})
+        >>> x1 = AD(np.e**2, 'x1')
         >>> f0 = AD.log(x1)
         >>> print(f0.func_val.round(1), f0.partial_dict)
         2.0 {'x1': 0.1353352832366127}
@@ -644,7 +688,7 @@ class AD():
             new_der_dict = x.partial_dict.copy()
             for var in new_der_dict.keys():
                 new_der_dict[var] = new_der_dict[var]/(x.func_val * np.log(base))
-            return AD(np.log(x.func_val), new_der_dict)
+            return AD(np.log(x.func_val), der_dict=new_der_dict)
         except AttributeError:
             # if x is not an AD class instance, treat as a constant
             return np.log(x) / np.log(base)
@@ -663,7 +707,7 @@ class AD():
         A new AD class with updated information
         Examples
         --------
-        >>> x1 = AD(0.0, {'x1': 1.0})
+        >>> x1 = AD(0.0, 'x1')
         >>> f1 = AD.sinh(x1)
         >>> print(f1.func_val, f1.partial_dict)
         0.0 {'x1': 1.0}
@@ -677,7 +721,7 @@ class AD():
             new_der_dict = x.partial_dict.copy()
             for var in new_der_dict.keys():
                 new_der_dict[var] = np.cosh(x.func_val)*new_der_dict[var]
-            return AD(np.sinh(x.func_val), new_der_dict)
+            return AD(np.sinh(x.func_val), der_dict=new_der_dict)
         except AttributeError:
             # if x is not an AD class instance, treat as a constant
             return np.sinh(x)
@@ -697,7 +741,7 @@ class AD():
         A new AD class with updated information
         Examples
         --------
-        >>> x1 = AD(0.0, {'x1': 1.0})
+        >>> x1 = AD(0.0, 'x1')
         >>> f1 = AD.cosh(x1)
         >>> print(f1.func_val.round(1), f1.partial_dict)
         1.0 {'x1': -0.0}
@@ -710,7 +754,7 @@ class AD():
             new_der_dict = x.partial_dict.copy()
             for var in new_der_dict.keys():
                 new_der_dict[var] = -np.sinh(x.func_val)*new_der_dict[var]
-            return AD(np.cosh(x.func_val), new_der_dict)
+            return AD(np.cosh(x.func_val), der_dict=new_der_dict)
         except AttributeError:
             # if x is not an AD class instance, treat as a constant
             return np.cosh(x)
@@ -729,7 +773,7 @@ class AD():
         A new AD class with updated information
         Examples
         --------
-        >>> x1 = AD(0.0, {'x1': 1.0})
+        >>> x1 = AD(0.0)
         >>> f1 = AD.tanh(x1)
         >>> print(f1.func_val.round(1), f1.partial_dict)
         0.0 {'x1': 1.0}
@@ -742,7 +786,7 @@ class AD():
             new_der_dict = x.partial_dict.copy()
             for var in new_der_dict.keys():
                 new_der_dict[var] = new_der_dict[var]/(np.cosh(x.func_val)**2)
-            return AD(np.tanh(x.func_val), new_der_dict)
+            return AD(np.tanh(x.func_val), der_dict=new_der_dict)
         except AttributeError:
             # if x is not an AD class instance, treat as a constant
             return np.tanh(x)
@@ -761,7 +805,7 @@ class AD():
         A new AD class with updated information
         Examples
         --------
-        >>> x = AD(2, {'x1': 1.})
+        >>> x = AD(2, 'x1')
         >>> print(AD.exp(x))
         7.3890560989306495 ({'x1': 7.3890560989306495})
         >>> x2 = 2
@@ -779,9 +823,7 @@ class AD():
         Parameters
         ----------
         x: AD class instance of float
-            Elements to be used as base of logistic function. Can be an AD class instance,
-            which will update both the function value and partial derivative dictionary; or
-            a constant, which will return a constant output
+            Elements to be used as base of logistic function. Can be an AD class instance/constant
         x_0: int or float 
             This represents the center of logistic function; default set to zero, i.e.
             logistic function centered at zero 0.
@@ -799,12 +841,12 @@ class AD():
         >>> x = AD(1.5)
         >>> print(AD.logistic(x))
         0.8175744761936437 ({'x1': 0.14914645207033284})
-        >>> f = x + AD(-0.5, {'x2': 1})
+        >>> f = x + AD(-0.5, 'x2')
         >>> print(AD.logistic(f))
         0.7310585786300049 ({'x1': 0.19661193324148188, 'x2': 0.19661193324148188})
         """
         return L/(1 + AD.exp(-k * (x - x_0)))
 
-if __name__ == '__main__':
-    import doctest
-    doctest.testmod()
+#if __name__ == '__main__':
+#    import doctest
+#    doctest.testmod()

--- a/docs/final_milestone_tasks.md
+++ b/docs/final_milestone_tasks.md
@@ -27,13 +27,13 @@ In terms of tasks remaining, we have the following:
 | Task                                                         | Team member | Status      |
 | ------------------------------------------------------------ | ----------- | ----------- |
 | Update existing functions for multiple inputs, where applicable | Minhuan     | Complete    |
-| `__eq__`, `__neq__`, other comparison operators              | Kevin       |             |
+| `__eq__`, `__neq__`, other comparison operators              | Kevin       | Complete    |
 | inverse trig functions (arcsine, arctan, arccos)             | Oksana      | In progress |
 | hyperbolic functions (sinh, tanh, cosh)                      | Timothy     | Complete    |
 | logistic function                                            | Kevin       | Complete    |
-| logarithm - expand to any base with default of e             | Timothy     | In progress |
+| logarithm - expand to any base with default of e             | Timothy     | Complete    |
 | square root                                                  | Timothy     | Complete    |
-| Update base class to support default seed vector             | Kevin       | In progress |
+| Update base class to support default seed vector             | Kevin       | Complete    |
 
 ##### Documentation, software organization, deliverables
 

--- a/docs/final_milestone_tasks.md
+++ b/docs/final_milestone_tasks.md
@@ -24,22 +24,23 @@ In terms of tasks remaining, we have the following:
 
 ##### Forward mode implementation
 
-| Task                                                         | Team member | Status |
-| ------------------------------------------------------------ | ----------- | ------ |
-| Update existing functions for multiple inputs, where applicable | Minhuan     |        |
-| `__eq__`, `__neq__`, other comparison operators              | Kevin       |        |
-| inverse trig functions (arcsine, arctan, arccos)             | Oksana      |        |
-| hyperbolic functions (sinh, tanh, cosh)                      | Timothy     |        |
-| logistic function                                            | Kevin       |        |
-| logarithm - expand to any base with default of e             | Timothy     |        |
-| square root                                                  | Timothy     |        |
+| Task                                                         | Team member | Status      |
+| ------------------------------------------------------------ | ----------- | ----------- |
+| Update existing functions for multiple inputs, where applicable | Minhuan     | Complete    |
+| `__eq__`, `__neq__`, other comparison operators              | Kevin       |             |
+| inverse trig functions (arcsine, arctan, arccos)             | Oksana      | In progress |
+| hyperbolic functions (sinh, tanh, cosh)                      | Timothy     | Complete    |
+| logistic function                                            | Kevin       | Complete    |
+| logarithm - expand to any base with default of e             | Timothy     | In progress |
+| square root                                                  | Timothy     | Complete    |
+| Update base class to support default seed vector             | Kevin       | In progress |
 
 ##### Documentation, software organization, deliverables
 
 | Task                                                         | Team member | Status      |
 | ------------------------------------------------------------ | ----------- | ----------- |
-| Discuss reorganization suggested by David                    | All         |             |
-| (TBD) Reorganize software package for optimization           | Kevin       |             |
+| Discuss reorganization suggested by David                    | All         | Complete    |
+| (TBD) Reorganize software package for optimization           | Kevin       | Complete    |
 | Add extension documentation to reflect implementation details |             |             |
 | Revise background & how-to-use sections                      |             |             |
 | Broader impact statement                                     | Timothy     |             |
@@ -48,12 +49,12 @@ In terms of tasks remaining, we have the following:
 
 ##### Optimization library
 
-| Task                                                         | Team member | Status |
-| ------------------------------------------------------------ | ----------- | ------ |
-| Base objective function class                                | Minhuan     |        |
-| 'set_params' method                                          | Minhuan     |        |
-| 'optimize' method                                            | Oksana      |        |
-| Implement gradient descent optimization                      | Oksana      |        |
-| Implement random coordinate descent (or other opt. algorithm) | TBD         |        |
-| Implement BFGS optimization                                  | Minhuan     |        |
+| Task                                                         | Team member | Status      |
+| ------------------------------------------------------------ | ----------- | ----------- |
+| Base objective function class                                | Minhuan     | In progress |
+| 'set_params' method                                          | Minhuan     |             |
+| 'optimize' method                                            | Oksana      |             |
+| Implement gradient descent optimization                      | Oksana      |             |
+| Implement random coordinate descent (or other opt. algorithm) | TBD         |             |
+| Implement BFGS optimization                                  | Minhuan     |             |
 

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -7,7 +7,7 @@ import numpy as np
 #creating templates that will be used to test the functions
 @pytest.fixture
 def trig_cls():
-    x = AD(np.pi/4, {'x1': 1.})
+    x = AD(np.pi/4, 'x1')
     return x
 
 @pytest.fixture
@@ -17,7 +17,7 @@ def trig_var():
 
 @pytest.fixture
 def basic_cls():
-    x = AD(2, {'x1': 1.})
+    x = AD(2, 'x1')
     return x
 
 @pytest.fixture

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -7,11 +7,23 @@ import pytest
 
 # Test initalization of base class
 def test_base():
-    x = AD(1, {'x1':1})
+    x = AD(1, der_dict={'x1':1})
     assert x.func_val == 1
     print(x.func_val)
     assert x.partial_dict['x1'] == 1
     assert len(x.partial_dict.keys()) == 1
+
+def test_base_name():
+    x = AD(1, 'x1')
+    assert x.func_val == 1
+    print(x.func_val)
+    assert x.partial_dict['x1'] == 1
+    assert len(x.partial_dict.keys()) == 1
+
+def test_base_onlyval():
+    x = AD(1)
+    assert x.func_val == 1
+    assert x.partial_dict == {'x1': 1}
     
 def test_badbaseval():
     # Test initialize base class without float or integer type
@@ -21,12 +33,12 @@ def test_badbaseval():
 def test_nonnum_dict_init():
     # Test values of passed dictionary are int or float
     with pytest.raises(ValueError):
-        x = AD(3.6, {'x1': 'bad'})
+        x = AD(3.6, der_dict={'x1': 'bad'})
         
 def test_nondict_init():
     # Test that if der_dict passed, it is dictionary 
     with pytest.raises(ValueError):
-        x = AD(1.5, 9.3)
+        x = AD(1.5, der_dict=9.3)
 
 def test_set_nonatt():
     # Test that set_params(att) must be one of 'func_val' or 'partial_dict'
@@ -51,6 +63,71 @@ def test_setparam_dictvals():
     with pytest.raises(ValueError):
         x = AD(12)
         x.set_params('partial_dict', {'x1': '3'})
+
+def test_name_str():
+    # Test if name is not a string
+    with pytest.raises(AttributeError):
+        x = AD(3.0, 2)
+
+def test_name_conflict():
+    with pytest.raises(Exception):
+        AD(2.5, 'x1', {'x2': 1})
+    
+
+# Test equality/inequality operators
+def test_equality():
+    # Test equality of operations
+    x = AD(12, 'x1')
+    y = AD(12)
+    assert x == y
+
+def test_equality_fval():
+    # Test equality of func_val
+    x = AD(12, 'x1')
+    z = AD(13)
+    assert (x == z) == False
+
+def test_equality_partial():
+    # Test equality of partial dictionary
+    x = AD(12, 'x1')
+    y = AD(12, 'x2')
+    assert (x == y) == False
+
+def test_equality_obj():
+    # test equality with non AD object
+    x = AD(12, 'x1')
+    assert (x == 12) == False
+    
+def test_inequality():
+    # Test basic inequality
+    x = AD(12, 'x1')
+    y = AD(9)
+    assert x != y
+
+def test_inequality_rev():
+    # Test reverse of inequality
+    x = AD(12, 'x1')
+    y = AD(12, 'x1')
+    assert (x != y) == False    
+
+def test_inequality_partial():
+    # Testinequality of partial dictionary
+    x = AD(12, 'x1')
+    y = AD(12, 'x2')
+    assert x != y
+
+def test_inequality_obj():
+    # test inequality compared to non-object
+    x = AD(12, 'x1')
+    assert x != 3
+    
+#### MISC TESTS
+def test_improper_logbase():
+    x = AD(3)
+    with pytest.raises(Exception):
+        AD.log(x, base = AD(4))
+        
+        
 
 def doctesting():
     doctest.testmod()


### PR DESCRIPTION
Note: this is an important update, as it adds a 'name' argument to the base class. This is an optional argument, and passing AD(4.5) will continue with same behavior. However, when specifying the new partial derivative dictionary, we must specify -- note that I retroactively did this and updated doc tests and rest of test suite.

E.g. AD(self.func_val + other.func_val, new_der_dict) will no longer work; augment to AD(self.func_val + other.func_val, der_dict=new_der_dict).